### PR TITLE
use optimize (not stats)

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -52,7 +52,7 @@ for f in all_properties
 end
 
 function __init__()
-    copy!(pyoptimize, pyimport_conda("scipy.stats", "scipy"))
+    copy!(pyoptimize, pyimport_conda("scipy.optimize", "scipy"))
 end
 
 


### PR DESCRIPTION
This PR assigns the appropriate module value to variable `pyoptimize`.

Fortunately since `pyoptimize` is updated in  https://github.com/AtsushiSakai/SciPy.jl/blob/c22bcb1a4e4b6183b100bea14e9a8efbc496873f/src/SciPy.jl#L342 again we could escape a bug. 😅 

Anyway let's fix this.