### PR TITLE
Impl constants module

### DIFF
--- a/src/SciPy.jl
+++ b/src/SciPy.jl
@@ -73,30 +73,6 @@ julia> SciPy.cluster.vq.kmeans(whitened, [whitened[1,:] whitened[3,:]] )
 """
 const cluster = PyNULL()
 
-"""
-scipy.constants module
-
-- [Constants (scipy.constants) Reference Guide](https://docs.scipy.org/doc/scipy/reference/constants.html)
-
-# Examples
-
-You can access each constants:
-
-```julia-repl
-julia> SciPy.constants.golden
-1.618033988749895
-
-julia> SciPy.constants.physical_constants["electron mass"] 
-(9.10938356e-31, "kg", 1.1e-38)
-
-julia> SciPy.constants.convert_temperature([-40, 40.0], "Celsius", "Kelvin") 
-
-2-element Array{Float64,1}:
- 233.14999999999998
- 313.15
-
-```
-"""
 const pyconstants = PyNULL()
 include("constants.jl")
 

--- a/src/SciPy.jl
+++ b/src/SciPy.jl
@@ -15,7 +15,7 @@ export print_configulations
 export cluster, constants, fft, integrate, interpolate, io, linalg, ndimage, odr
 export optimize, signal, sparse, spatial, stats, special
 # raw PyObject modules
-export pystats, pyoptimize, pyinterpolate, pyspatial
+export pyconstants, pystats, pyoptimize, pyinterpolate, pyspatial
 
 
 const scipy = PyNULL()
@@ -98,6 +98,7 @@ julia> SciPy.constants.convert_temperature([-40, 40.0], "Celsius", "Kelvin")
 ```
 """
 const constants = PyNULL()
+const pyconstants = PyNULL()
 
 """
 scipy.fft module
@@ -341,6 +342,7 @@ function __init__()
     copy!(pystats, pyimport_conda("scipy.stats", "scipy"))
     copy!(pyoptimize, pyimport_conda("scipy.optimize", "scipy"))
     copy!(pyinterpolate, pyimport_conda("scipy.interpolate", "scipy"))
+    copy!(pyconstants, pyimport_conda("scipy.constants", "scipy"))
 end
 
 """

--- a/src/SciPy.jl
+++ b/src/SciPy.jl
@@ -97,8 +97,8 @@ julia> SciPy.constants.convert_temperature([-40, 40.0], "Celsius", "Kelvin")
 
 ```
 """
-const constants = PyNULL()
 const pyconstants = PyNULL()
+include("constants.jl")
 
 """
 scipy.fft module
@@ -327,7 +327,6 @@ Module initialization function
 function __init__()
     copy!(scipy, pyimport_conda("scipy", "scipy"))
     copy!(cluster, pyimport_conda("scipy.cluster", "scipy"))
-    copy!(constants, pyimport_conda("scipy.constants", "scipy"))
     copy!(fft, pyimport_conda("scipy.fft", "scipy"))
     copy!(integrate, pyimport_conda("scipy.integrate", "scipy"))
     copy!(io, pyimport_conda("scipy.io", "scipy"))

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -51,7 +51,7 @@ function __init__()
     for f in apis["constant"]
         f in _ignore_funcs && continue # just in case
         sf = Symbol(f)
-        @eval @doc LazyHelp(pyconstants, $f) const $sf = getproperty(pyconstants, Symbol($f))
+        @eval @doc LazyHelp(pyconstants, $f) const $sf = convert(PyAny, getproperty(pyconstants, $f))
     end
 end
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -15,8 +15,7 @@ julia> SciPy.constants.physical_constants["electron mass"]
 (9.10938356e-31, "kg", 1.1e-38)
 
 julia> SciPy.constants.convert_temperature([-40, 40.0], "Celsius", "Kelvin")
-
-2-element Array{Float64,1}:
+2-element Vector{Float64}:
  233.14999999999998
  313.15
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,3 +1,27 @@
+"""
+scipy.constants module
+
+- [Constants (scipy.constants) Reference Guide](https://docs.scipy.org/doc/scipy/reference/constants.html)
+
+# Examples
+
+You can access each constants:
+
+```julia-repl
+julia> SciPy.constants.golden
+1.618033988749895
+
+julia> SciPy.constants.physical_constants["electron mass"]
+(9.10938356e-31, "kg", 1.1e-38)
+
+julia> SciPy.constants.convert_temperature([-40, 40.0], "Celsius", "Kelvin")
+
+2-element Array{Float64,1}:
+ 233.14999999999998
+ 313.15
+
+```
+"""
 module constants
 
 using PyCall

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,0 +1,35 @@
+module constants
+
+using PyCall
+
+pyimport_conda("scipy", "scipy")
+@pyinclude(joinpath(pkgdir(@__MODULE__), "src", "scipy_api_list.py"))
+apis = py"generate_scipy_apis"("constants")
+
+all_properties = [apis["function"]; apis["class"]; apis["constant"]]
+
+import ..pyconstants
+
+import ..LazyHelp
+
+const _ignore_funcs = ["constants"]
+
+for f in [apis["function"]; apis["class"]]
+    f in _ignore_funcs && continue
+
+    sf = Symbol(f)
+    @eval @doc LazyHelp(pyconstants, $f) $sf(args...; kws...) =
+        pycall(pyconstants.$f, PyAny, args...; kws...)
+end
+
+function __init__()
+    copy!(pyconstants, pyimport_conda("scipy.constants", "scipy"))
+    for f in apis["constant"]
+        f in _ignore_funcs && continue # just in case
+        sf = Symbol(f)
+        @eval @doc LazyHelp(pyconstants, $f) const $sf = getproperty(pyconstants, Symbol($f))
+    end
+end
+
+
+end # module

--- a/src/scipy_api_list.py
+++ b/src/scipy_api_list.py
@@ -56,11 +56,15 @@ def generate_scipy_apis(pymod) -> dict:
     d = defaultdict(list)
     attributes = sorted(set(pymod.__all__))
     for attr in attributes:
+        is_const = True
         for (key, method) in types:
             condition = eval(f"inspect.{method}(pymod.{attr})")
             if condition:
                 d[key].append(attr)
+                is_const = False
                 break
+        if is_const:
+            d["constant"].append(attr)
 
     return dict(d)
 

--- a/src/scipy_api_list.py
+++ b/src/scipy_api_list.py
@@ -64,7 +64,6 @@ def generate_scipy_apis(pymod) -> dict:
                 is_const = False
                 break
         if is_const:
-            # required to setup `constants` module
             d["constant"].append(attr)
 
     return dict(d)

--- a/src/scipy_api_list.py
+++ b/src/scipy_api_list.py
@@ -56,15 +56,11 @@ def generate_scipy_apis(pymod) -> dict:
     d = defaultdict(list)
     attributes = sorted(set(pymod.__all__))
     for attr in attributes:
-        is_const = True
         for (key, method) in types:
             condition = eval(f"inspect.{method}(pymod.{attr})")
             if condition:
                 d[key].append(attr)
-                is_const = False
                 break
-        if is_const:
-            d["constant"].append(attr)
 
     return dict(d)
 

--- a/src/scipy_api_list.py
+++ b/src/scipy_api_list.py
@@ -64,6 +64,7 @@ def generate_scipy_apis(pymod) -> dict:
                 is_const = False
                 break
         if is_const:
+            # required to setup `constants` module
             d["constant"].append(attr)
 
     return dict(d)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ using Test
 
     @testset "constants" begin
         @test constants.golden == 1.618033988749895
+        @test typeof(pyconstants.golden) == typeof(constants.golden)
     end
 
     @testset "fft" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,11 @@ using Test
     @testset "constants" begin
         @test constants.golden == 1.618033988749895
         @test typeof(pyconstants.golden) == typeof(constants.golden)
+
+        @test constants.convert_temperature([-40, 40.0], "Celsius", "Kelvin") ≈ [233.14999999999998, 313.15]
+
+        @test typeof(pyconstants.physical_constants) == typeof(constants.physical_constants)
+        @test constants.physical_constants["electron mass"] == (9.1093837015e-31, "kg", 2.8e-40)
     end
 
     @testset "fft" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,8 +20,13 @@ using Test
     end
 
     @testset "constants" begin
+        @test constants.zero_Celsius == 273.15
         @test constants.golden == 1.618033988749895
+        @test constants.centi == 0.01
+
+        @test typeof(pyconstants.zero_Celsius) == typeof(constants.zero_Celsius)
         @test typeof(pyconstants.golden) == typeof(constants.golden)
+        @test typeof(pyconstants.centi) == typeof(constants.centi)
 
         @test constants.convert_temperature([-40, 40.0], "Celsius", "Kelvin") ≈ [233.14999999999998, 313.15]
 


### PR DESCRIPTION
resolve #46 

Example

```julia
julia> using SciPy
julia> pyconstants

PyObject <module 'scipy.constants' from '~/.asdf/installs/python/3.8.10/lib/python3.8/site-packages/scipy/constants/__init__.py'>

julia> typeof(constants)
Module

julia> pyconstants.golden
1.618033988749895

julia> constants.golden
1.618033988749895
```